### PR TITLE
Update to new October dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # The United States (US) Research Software Engineer Association Workshop
 
 This is website landing page for the US-RSE Association planning workshop to be
-held in Princeton, NJ April 21-22, 2020.
+held in Princeton, NJ October 27-28, 2020.

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # DO NOT CHANGE THE LINE NUMBERS HERE without changing .circleci/circle_urls.sh
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "https://us-rse.org"
-baseurl: "/2020-april-workshop"  # for testing, also check .circleci/circle_urls.sh
+baseurl: "/2020-oct-workshop"  # for testing, also check .circleci/circle_urls.sh
 title-img: /assets/img/logo_600px.png  # baseurl will be prepended
 twitter-img: /assets/img/logo_600px.png  # url + baseurl will be prepended
 
@@ -16,10 +16,10 @@ twitter-img: /assets/img/logo_600px.png  # url + baseurl will be prepended
 # Of course don't forget to change the username and projectname to YOUR username and project
 
 # Name of website
-title: US-RSE April 2020 Workshop
+title: US-RSE October 2020 Workshop
 
 # Short description of your site
-description: April 2020 Community Buiding Workshop
+description: October 2020 Community Buiding Workshop
 
 # --- Navigation bar options --- #
 

--- a/_posts/2020-03-26-rescheduled-update.md
+++ b/_posts/2020-03-26-rescheduled-update.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Workshop Rescheduled to Fall 2020
+date: 2020-03-26
+tags:
+---
+
+
+The US-RSE Community Building Workshop has been officially rescheduled
+for October 27-28, 2020.  It will still be held at the same venue, the
+Nassau Inn in Princeton, NJ.
+
+This is a rapidly changing situation and it is impossible to predict
+what the travel/conference landscape will look like in October.
+Should COVID-19 continue to prevent us from having the workshop in
+October, we may need to reschedule for sometime in the following 12 months.
+Though we certainly hope it doesn’t come to that.
+

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: US-RSE Community Building Workshop
-subtitle: Fall 2020 in Princeton, NJ
+subtitle: October 27-28 2020 in Princeton, NJ
 use-site-title: true
 fb-img:
 ---
@@ -10,6 +10,7 @@ fb-img:
 <div class="main-explain-area jumbotron">
 
 <h2>UPDATES</h2>
+  <p> March 26, 2020: <a href='{{ site.baseurl }}/2020-03-26-rescheduled-update/'>Workshop Resecheduled</a>.</p>
   <p> March 9, 2020: <a href='{{ site.baseurl }}/2020-03-09-coronavirus-update/'>Workshop Postponed</a>.</p>
   <p> March 6, 2020: <a href='{{ site.baseurl }}/2020-03-06-coronavirus-update/'>COVID-19 Update</a>.</p>
 
@@ -19,7 +20,7 @@ fb-img:
   <h2> First RSE Workshop </h2>
   <p> We are excited to announce that through a generous grant from the Alfred
     P. Sloan Foundation, we will be able to hold a first US-RSE Association
-    community building workshop, in Princeton, NJ (date TBD). This will
+    community building workshop, in Princeton, NJ October 27-28, 2020. This will
     be a workshop focused on planning the best path forward to grow the
     <a href='https://us-rse.org'>US-RSE Association</a>. This workshop promises
     to be an important milestone in the growth of the US-RSE Association!</p>

--- a/pages/agenda.md
+++ b/pages/agenda.md
@@ -10,7 +10,7 @@ Please note this is preliminary and likely to change!
 
 Read more about the workshop goals [here]({{ site.baseurl }}/about)
 
-## Day 1 - Tuesday, April 21
+## Day 1 - Tuesday, October 27
 
 
 | Time | Session Title |
@@ -33,7 +33,7 @@ Read more about the workshop goals [here]({{ site.baseurl }}/about)
 
 <br>
 
-## Day 2 - Wednesday, April 22
+## Day 2 - Wednesday, October 28
 
 | Time | Session Title |
 | ------ | ----- |

--- a/pages/travel.md
+++ b/pages/travel.md
@@ -15,7 +15,7 @@ visiting Princeton.
 Please send any questions about travel to the workshop to Andrea Rubinstein.
 
 ## Travel Reimbursement
-All participant costs will be covered by the grant. However, please do not make travel arrangements yet. Details as to how to proceed will be sent to all participants in early February.  
+All participant costs will be covered by the grant. However, please do not make travel arrangements yet. Details as to how to proceed will be sent to all participants before the workshop.  
 
 
 ## Travel by Train


### PR DESCRIPTION
This updates the workshop dates to the new October dates.  It also adds a dated update for today.

It will also change the site address, so after this is merged we need to change the repo name to 2020-oct-workhshop.