### PR TITLE
Change url to "first-community-workshop"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # DO NOT CHANGE THE LINE NUMBERS HERE without changing .circleci/circle_urls.sh
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "https://us-rse.org"
-baseurl: "/2020-oct-workshop"  # for testing, also check .circleci/circle_urls.sh
+baseurl: "/first-community-workshop"  # for testing, also check .circleci/circle_urls.sh
 title-img: /assets/img/logo_600px.png  # baseurl will be prepended
 twitter-img: /assets/img/logo_600px.png  # url + baseurl will be prepended
 


### PR DESCRIPTION
This way we're protected in case it doesn't happen in October, or even 2020.

Once it's merged, we'll also need to change the repo name to match.  Then I can add a redirect on the main page.