### PR TITLE
Update site to change to 2021

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,10 @@ twitter-img: /assets/img/logo_600px.png  # url + baseurl will be prepended
 # Of course don't forget to change the username and projectname to YOUR username and project
 
 # Name of website
-title: US-RSE October 2020 Workshop
+title: US-RSE October 2021 Workshop
 
 # Short description of your site
-description: October 2020 Community Buiding Workshop
+description: October 2021 Community Buiding Workshop
 
 # --- Navigation bar options --- #
 

--- a/_posts/2020-07-28-coronavirus-update.md
+++ b/_posts/2020-07-28-coronavirus-update.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: US-RSE Workshop Again Postponed Due to COVID-19
+date: 2020-07-28
+tags:
+---
+
+
+Due to the continued COVID-19 Pandemic, we have again made the
+unfortunate but necessary decision to postpone the US-RSE Community
+Building Workshop. Given current state travel restrictions requiring
+people to quarantine, and numerous employers not allowing business
+travel, it was impossible to believe we could have a successful
+workshop in October of this year.
+
+The workshop has been postponed until October 5-6, 2021. If the
+pandemic improves significantly in the short term, we will consider
+moving it earlier in 2021 depending on hotel/venue availability.
+
+In the months before the workshop, we will advertise and restart the
+application/invitation process. We will communicate with the broader
+US-RSE community as to the timing and next steps. Expect occasional updates to
+also be posted here on the workshop website.
+
+

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: US-RSE Community Building Workshop
-subtitle: October 27-28 2020 in Princeton, NJ
+subtitle: October 5-6, 2021 in Princeton, NJ
 use-site-title: true
 fb-img:
 ---
@@ -21,7 +21,7 @@ fb-img:
   <h2> First RSE Workshop </h2>
   <p> We are excited to announce that through a generous grant from the Alfred
     P. Sloan Foundation, we will be able to hold a first US-RSE Association
-    community building workshop, in Princeton, NJ October 27-28, 2020. This will
+    community building workshop, in Princeton, NJ October 5-6, 2020. This will
     be a workshop focused on planning the best path forward to grow the
     <a href='https://us-rse.org'>US-RSE Association</a>. This workshop promises
     to be an important milestone in the growth of the US-RSE Association!</p>
@@ -37,20 +37,8 @@ fb-img:
     <a href='{{ site.baseurl }}/agenda'>preliminary agenda</a> </p>
   <br>
 
-  <p>More specific information and details will follow in the coming weeks.
-    </p>
+  
 
-<!-- <h2> What is the US-RSE Association? </h2>
-  <p>Initiatives in the <a href='http://rse.ac.uk/'>UK</a>, <a href='http://www.de-rse.org/en'>Germany</a>,
-  the <a href='http://nl-rse.org'>Netherlands</a> and elsewhere are bringing
-  together the community of people writing and contributing to research software at
-  the national and international level. In the US this encompasses
-  universities, laboratories, knowledge institutes, companies and other
-  enterprises. This site is part of that effort.</p>
-  <div class="get-started-wrap">
-    <a class="btn btn-success btn-lg get-started-btn" href="https://forms.gle/CRsH7sKAk3UvZJfB9" target="_blank">Join the US-RSE Association!</a>
-  </div>
-  -->
 </div>
 
 

--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@ fb-img:
 <div class="main-explain-area jumbotron">
 
 <h2>UPDATES</h2>
-  <p> March 26, 2020: <a href='{{ site.baseurl }}/2020-07-28-coronavirus-update/'>Workshop Resecheduled to 2021</a>.</p>
-  <p> March 26, 2020: <a href='{{ site.baseurl }}/2020-03-26-rescheduled-update/'>Workshop Resecheduled</a>.</p>
-  <p> March 9, 2020: <a href='{{ site.baseurl }}/2020-03-09-coronavirus-update/'>Workshop Postponed</a>.</p>
-  <p> March 6, 2020: <a href='{{ site.baseurl }}/2020-03-06-coronavirus-update/'>COVID-19 Update</a>.</p>
+  <p> July 28, 2020: <a href='{{ site.baseurl }}/2020-07-28-coronavirus-update/'>Workshop Resecheduled to 2021</a></p>
+  <p> March 26, 2020: <a href='{{ site.baseurl }}/2020-03-26-rescheduled-update/'>Workshop Resecheduled</a></p>
+  <p> March 9, 2020: <a href='{{ site.baseurl }}/2020-03-09-coronavirus-update/'>Workshop Postponed</a></p>
+  <p> March 6, 2020: <a href='{{ site.baseurl }}/2020-03-06-coronavirus-update/'>COVID-19 Update</a></p>
 
 
 <br>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ fb-img:
   <h2> First RSE Workshop </h2>
   <p> We are excited to announce that through a generous grant from the Alfred
     P. Sloan Foundation, we will be able to hold a first US-RSE Association
-    community building workshop, in Princeton, NJ October 5-6, 2020. This will
+    community building workshop, in Princeton, NJ October 5-6, 2021. This will
     be a workshop focused on planning the best path forward to grow the
     <a href='https://us-rse.org'>US-RSE Association</a>. This workshop promises
     to be an important milestone in the growth of the US-RSE Association!</p>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@ fb-img:
 <div class="main-explain-area jumbotron">
 
 <h2>UPDATES</h2>
+  <p> March 26, 2020: <a href='{{ site.baseurl }}/2020-07-28-coronavirus-update/'>Workshop Resecheduled to 2021</a>.</p>
   <p> March 26, 2020: <a href='{{ site.baseurl }}/2020-03-26-rescheduled-update/'>Workshop Resecheduled</a>.</p>
   <p> March 9, 2020: <a href='{{ site.baseurl }}/2020-03-09-coronavirus-update/'>Workshop Postponed</a>.</p>
   <p> March 6, 2020: <a href='{{ site.baseurl }}/2020-03-06-coronavirus-update/'>COVID-19 Update</a>.</p>

--- a/pages/agenda.md
+++ b/pages/agenda.md
@@ -10,7 +10,7 @@ Please note this is preliminary and likely to change!
 
 Read more about the workshop goals [here]({{ site.baseurl }}/about)
 
-## Day 1 - Tuesday, October 27
+## Day 1 - Tuesday, October 5
 
 
 | Time | Session Title |
@@ -33,7 +33,7 @@ Read more about the workshop goals [here]({{ site.baseurl }}/about)
 
 <br>
 
-## Day 2 - Wednesday, October 28
+## Day 2 - Wednesday, October 6
 
 | Time | Session Title |
 | ------ | ----- |

--- a/pages/application.md
+++ b/pages/application.md
@@ -4,17 +4,16 @@ title: Application
 permalink: /application/
 ---
 
-Thank you to everyone who expressed interest in attending the
-workshop.  Unfortunately, we received significantly more applicants
-than we are able to support.
 
-We are striving to accommodate as many as possible, but workshop space
+
+Thank you to everyone who expressed interest in attending the original
+workshop. Because of the time that has passed since the initial call
+for participation and the rescheduled workshop, we will reopen the
+call in 2021. Please check back closer to the new workshop date for
+information about how to participate in the workshop.
+
+We will strive to accommodate as many as possible, but workshop space
 is limited and we are committed to ensuring a broadly diverse
 participant group, both in terms of traditional diversity measures as
 well as research domain and institutional representation.
 
-While we will not be able to provide remote participation during the
-workshop (check back [here]({{ site.baseurl }}/get-involved) for other
-ways to get involved) we are actively working on organizing additional
-community building events, potentially as part of an existing
-conference or workshop.

--- a/pages/venue.md
+++ b/pages/venue.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Venue
-subtitle: Fall 2020
+subtitle: Fall 2021
 permalink: /venue/
 ---
 


### PR DESCRIPTION
This PR: 

1. Updates all workshop dates to the new ones in 2021
1. Adds a post and top update link with an explanation of the schedule change
1. Updates the application page to say that we will reopen the call as it gets closer

I've previewed everything locally. Any suggestions welcome.

Once this is live I'll send an email to everyone who was on the participant list. 

